### PR TITLE
Handle igblastn crashes and show error output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.1.1 - 2021-12-06
+## 0.1.1 - 2021-12-07
 
 ### Changed
 
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+ * IgBLAST output is now shown even if it crashes ([#12])
  * Header-only CSV/TSV files no longer crash the show command ([#8])
  * summarize command now works with multiple references ([#7])
  * vdj-match and summarize commands now work as intended via igblast, and all
@@ -17,6 +18,7 @@
  * Duplicate FASTA paths found in vdj-gather will no longer result in
    duplicated output sequences ([#2])
 
+[#12]: https://github.com/ShawHahnLab/igseq/pull/12
 [#8]: https://github.com/ShawHahnLab/igseq/pull/8
 [#7]: https://github.com/ShawHahnLab/igseq/pull/7
 [#5]: https://github.com/ShawHahnLab/igseq/pull/5

--- a/igseq/igblast.py
+++ b/igseq/igblast.py
@@ -69,10 +69,15 @@ def igblast(
     species_det = {s for s in species_det if s}
     organism = detect_organism(species_det, species)
     if not dry_run:
-        proc, _ = setup_db_dir_and_igblast(
-            [attrs["path"] for attrs in attrs_list],
-            organism, query_path, db_path, threads, extra_args,
-            capture_output=True, text=True, check=True)
+        try:
+            proc, _ = setup_db_dir_and_igblast(
+                [attrs["path"] for attrs in attrs_list],
+                organism, query_path, db_path, threads, extra_args,
+                capture_output=True, text=True, check=True)
+        except subprocess.CalledProcessError as err:
+            sys.stdout.write(err.stdout)
+            sys.stderr.write(err.stderr)
+            raise util.IgSeqError("IgBLAST crashed") from err
         sys.stdout.write(proc.stdout)
         sys.stderr.write(proc.stderr)
 

--- a/test_igseq/test_igblast.py
+++ b/test_igseq/test_igblast.py
@@ -62,3 +62,21 @@ class TestIgblastLive(TestBase, TestLive):
                 btwn(stdout, 2, 97),
                 btwn(stdout_exp, 2, 97))
         self.assertEqual(stderr, "")
+
+
+class TestIgblastLiveCrash(TestBase, TestLive):
+    """Test that an igblastn crash is handled"""
+
+    def test_igblast(self):
+        """Test that an igblastn crash is caught and re-raised as an IgSeqError.
+
+        Standard error and output from the igblastn process should still show
+        up on stderr and stdout as usual.
+        """
+        def catch_expected_error():
+            with self.assertRaises(IgSeqError):
+                igblast.igblast(
+                    ["rhesus/imgt"], self.path/"input/query.fasta", extra_args=["-bad-arg"])
+        stdout, stderr = self.redirect_streams(catch_expected_error)
+        self.assertEqual(stdout, "")
+        self.assertIn('Error: Unknown argument: "bad-arg"', stderr)


### PR DESCRIPTION
igblastn's stdout/stderr messages will be shown even if the process crashes.  Fixes #11.