### PR TITLE
Skip refs with missing segments in vdj-match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## dev
+
+### Fixed
+
+ * vdj-match now skips references that are missing gene segments but were only
+   included implicitly rather than directly named ([#25])
+
+[#25]: https://github.com/ShawHahnLab/igseq/pull/25
+
 ## 0.2.0 - 2022-02-15
 
 ### Added

--- a/test_igseq/data/test_vdj_match/TestVDJMatchLive/output/stdout_multi.txt
+++ b/test_igseq/data/test_vdj_match/TestVDJMatchLive/output/stdout_multi.txt
@@ -1,0 +1,10 @@
+ query          reference segment                    call length identity
+ query  rhesus/bernat2021       V            IGHV4-117*01    296   99.324
+ query  rhesus/bernat2021       D             IGHD4-23*01      9  100.000
+ query  rhesus/bernat2021       J              IGHJ4-3*01     45  100.000
+ query        rhesus/imgt       V            IGHV4-173*01    296   99.324
+ query        rhesus/imgt       D IGHD4-23*01,IGHD4-41*01      9  100.000
+ query        rhesus/imgt       J                IGHJ4*01     45  100.000
+ query rhesus/sonarramesh       V            IGHV4-AFI*01    294   95.960
+ query rhesus/sonarramesh       D IGHD4-22*01,IGHD4-37*01      9  100.000
+ query rhesus/sonarramesh       J                IGHJ4*01     45  100.000

--- a/test_igseq/test_vdj_match.py
+++ b/test_igseq/test_vdj_match.py
@@ -16,6 +16,19 @@ class TestVDJMatchLive(TestBase, TestLive):
             stdout_exp = f_in.read()
         self.assertEqual(stdout_exp, stdout)
 
+    def test_vdj_match_multi(self):
+        # with all matching rhesus refs selected, we should get a block of
+        # output rows for each ref found.  but, the zhang2019 ref only has V
+        # and J so it's not usable as a standalone IgBLAST DB.  We'll get a
+        # warning about skipping that one, and output rows for imgt/
+        # sonarramesh/bernat2021.
+        stdout, stderr = self.redirect_streams(
+            lambda: vdj_match.vdj_match(["rhesus"], self.path/"input/query.fasta"))
+        self.assertEqual(stderr, 'No FASTA for D from rhesus/zhang2019; skipping\n')
+        with open(self.path/"output/stdout_multi.txt") as f_in:
+            stdout_exp = f_in.read()
+        self.assertEqual(stdout_exp, stdout)
+
     def test_vdj_match_csv(self):
         # CSV input should be supported
         stdout, stderr = self.redirect_streams(

--- a/test_igseq/test_vdj_match.py
+++ b/test_igseq/test_vdj_match.py
@@ -29,6 +29,16 @@ class TestVDJMatchLive(TestBase, TestLive):
             stdout_exp = f_in.read()
         self.assertEqual(stdout_exp, stdout)
 
+    def test_vdj_match_missing(self):
+        # If we explicitly request a reference that's missing segments, though,
+        # that warning becomes an error.
+        def wrapper():
+            with self.assertRaisesRegex(IgSeqError, "Missing VDJ input for database"):
+                vdj_match.vdj_match(["rhesus/zhang2019"], self.path/"input/query.fasta")
+        stdout, stderr = self.redirect_streams(wrapper)
+        self.assertEqual(stdout, "")
+        self.assertEqual(stderr, 'No FASTA for D from rhesus/zhang2019\n')
+
     def test_vdj_match_csv(self):
         # CSV input should be supported
         stdout, stderr = self.redirect_streams(


### PR DESCRIPTION
Makes vdj-match skip any references that are missing one or more segments (if they were included implicitly) and show a warning instead of failing.  Fixes #24.