### PR TITLE
Handle broken pipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## dev
+
+### Fixed
+
+ * broken pipes (such as from `igseq something | something else`) are now
+   handled gracefully ([#30])
+
+[#30]: https://github.com/ShawHahnLab/igseq/pull/30
+
 ## 0.3.0 - 2022-07-14
 
 ### Added

--- a/test_igseq/data/test_cmds/TestCmds/broken_pipe.sh
+++ b/test_igseq/data/test_cmds/TestCmds/broken_pipe.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# For #20
+# Run a big igblast query but only read one line from stdout
+set -e -o pipefail
+python -m igseq igblast -r rhesus/imgt -Q <(python -m igseq show IGHV fasta 2> /dev/null) --input-format fa 2> /dev/null | head -n 1 > /dev/null

--- a/test_igseq/test_cmds.py
+++ b/test_igseq/test_cmds.py
@@ -1,0 +1,27 @@
+"""
+Special case of one-off external commands for misc tests.
+
+Each calls a bash script that should exit 0 if it worked, nonzero otherwise.
+"""
+
+import inspect
+from subprocess import run
+from .util import TestBase
+
+class TestCmds(TestBase):
+    """Misc tests contained in standalone bash scripts."""
+
+    def test_broken_pipe(self):
+        """Test that broken pipes are handled gracefully for an igblast call."""
+        self.runcmd()
+
+    def runcmd(self):
+        """Run the test bash script associated with the calling function.
+
+        This is either clever or idiotic.  Time will tell.
+        """
+        frame = inspect.currentframe()
+        parent = inspect.getouterframes(frame)[1][0]
+        func = inspect.getframeinfo(parent).function
+        script = self.path / (func.removeprefix("test_") + ".sh")
+        run(script, check=True)


### PR DESCRIPTION
If igseq's stdout is closed (such as from another process working with its output) this will try to gracefully handle the closed pipe, including for an igblastn subprocess.  Fixes #20.  I think.