### PR TITLE
Make identity command disregard gaps and uppercase/lowercase differences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
  * `identity` command for calculating pairwise identity between arbitrary
-   queries and references ([#31])
+   queries and references ([#31], [#37])
  * Support for showing basic tree topology for Newick-format files in `show`
    command ([#33])
 
@@ -15,6 +15,7 @@
  * broken pipes (such as from `igseq something | something else`) are now
    handled gracefully ([#30])
 
+[#37]: https://github.com/ShawHahnLab/igseq/pull/37
 [#35]: https://github.com/ShawHahnLab/igseq/pull/35
 [#33]: https://github.com/ShawHahnLab/igseq/pull/33
 [#31]: https://github.com/ShawHahnLab/igseq/pull/31

--- a/igseq/identity.py
+++ b/igseq/identity.py
@@ -10,7 +10,8 @@ allows, for example, junction sequences from an AIRR tsv as queries and a FASTA
 of known junctions as references.
 
 The scoring is based on a simple global pairwise alignment, with matches scored
-as 1, mismatches and gaps 0.
+as 1, mismatches and gaps 0.  Any existing gaps are removed before comparing
+sequences, and differeces in case (lower/upper) are disregarded.
 """
 
 import logging
@@ -68,5 +69,12 @@ def score_identity(seq1, seq2):
     """
     # These can be strings or Seq objects, but not SeqRecords.
     if seq1 and seq2:
+        # We'll disregard gaps and case.  If whatever these objects are can't
+        # handle those methods we'll throw a ValueError.
+        try:
+            seq1 = seq1.replace("-", "").upper()
+            seq2 = seq2.replace("-", "").upper()
+        except AttributeError as err:
+            raise ValueError("score_identity arguments should be Seq objects or strings") from err
         return ALIGNER.score(seq1, seq2)/max(len(seq1), len(seq2))
     return 0

--- a/test_igseq/test_identity.py
+++ b/test_igseq/test_identity.py
@@ -138,6 +138,8 @@ class TestScoreIdentity(unittest.TestCase):
         # without also needing a lot of extra metadata tracking.)
         cases = [
             ("ACTG", "ACTG", 1.00), # identical
+            ("AC-G", "A-CG", 1.00), # identical (gaps disregarded)
+            ("ACTG", "actg", 1.00), # identical (case disregarded)
             ("ACTG",     "", 0.00), # one blank -> 0 by definition
             (    "", "ACTG", 0.00), # other blank -> 0 by definition
             (    "",     "", 0.00), # both blank -> 0 by definition


### PR DESCRIPTION
Updates the recently-added `identity` command to disregard gaps and uppercase/lowercase differences when comparing sequences.  Fixes #36.