### PR TITLE
Default to all available references for a given species for IgBLAST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+ * Automatic usage of all available references for a given species in `igblast`
+   command ([#39])
  * `identity` command for calculating pairwise identity between arbitrary
    queries and references ([#31], [#37])
  * Support for showing basic tree topology for Newick-format files in `show`
@@ -15,6 +17,7 @@
  * broken pipes (such as from `igseq something | something else`) are now
    handled gracefully ([#30])
 
+[#39]: https://github.com/ShawHahnLab/igseq/pull/39
 [#37]: https://github.com/ShawHahnLab/igseq/pull/37
 [#35]: https://github.com/ShawHahnLab/igseq/pull/35
 [#33]: https://github.com/ShawHahnLab/igseq/pull/33


### PR DESCRIPTION
When a species name is given to the igblast subcommand but no references, this will automatically use all available references for that species.  Fixes #38.