### PR TITLE
Default to all available references for a given species for summarize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+ * `summarize` command will automatically use all available references for a
+   given species if a species is given but no references ([#50])
  * `tree` command for creating and formatting phylogenetic trees ([#44])
  * support for additional arguments for `getreads` command passed through to
    bcl2fastq ([#43])
@@ -15,6 +17,7 @@
  * `identity` command now uses a custom sequence ID column if one is given
    ([#49])
 
+[#50]: https://github.com/ShawHahnLab/igseq/pull/50
 [#49]: https://github.com/ShawHahnLab/igseq/pull/49
 [#44]: https://github.com/ShawHahnLab/igseq/pull/44
 [#43]: https://github.com/ShawHahnLab/igseq/pull/43

--- a/igseq/igblast.py
+++ b/igseq/igblast.py
@@ -73,7 +73,7 @@ def igblast(
     if species and not ref_paths:
         # If only species is given, default to using all available reference
         # sets for that species
-        ref_paths = [_fuzzy_species_match(species)]
+        ref_paths = [fuzzy_species_match(species)]
         LOGGER.info("inferred ref path: %s", ref_paths[0])
     attrs_list = vdj.parse_vdj_paths(ref_paths)
     for attrs in attrs_list:
@@ -109,7 +109,7 @@ def detect_organism(species_det, species=None):
         species = species_det.pop()
         LOGGER.info("detected species: %s", species)
     # match species names if needed
-    species_new = _fuzzy_species_match(species)
+    species_new = fuzzy_species_match(species)
     if species_new != species:
         LOGGER.info(
             "detected species as synonym: %s -> %s", species, species_new)
@@ -122,7 +122,7 @@ def detect_organism(species_det, species=None):
     LOGGER.info("detected IgBLAST organism: %s", organism)
     return organism
 
-def _fuzzy_species_match(species):
+def fuzzy_species_match(species):
     """Fuzzy-match one of our species names"""
     species_key = re.sub("[^a-z]", "", species.lower())
     try:

--- a/igseq/summarize.py
+++ b/igseq/summarize.py
@@ -24,6 +24,11 @@ def summarize(ref_paths, query, output=None, showtxt=None, species=None, fmt_in=
     LOGGER.info("given input format: %s", fmt_in)
     LOGGER.info("given colmap: %s", colmap)
     LOGGER.info("given threads: %s", threads)
+    if species and not ref_paths:
+        # If only species is given, default to using all available reference
+        # sets for that species
+        ref_paths = [igblast.fuzzy_species_match(species)]
+        LOGGER.info("inferred ref path: %s", ref_paths[0])
     # if not specified, show text when not saving output
     if showtxt is None:
         showtxt = not output


### PR DESCRIPTION
When a species name is given to the `summarize` subcommand but no references, this will automatically use all available references for that species.  Fixes #46.