### PR TITLE
Support sequence descriptions in input and output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,12 @@
 
 ### Fixed
 
+ * `convert` command and underlying input/output features now handles sequence
+   descriptions ([#51])
  * `identity` command now uses a custom sequence ID column if one is given
    ([#49])
 
+[#51]: https://github.com/ShawHahnLab/igseq/pull/51
 [#50]: https://github.com/ShawHahnLab/igseq/pull/50
 [#49]: https://github.com/ShawHahnLab/igseq/pull/49
 [#44]: https://github.com/ShawHahnLab/igseq/pull/44

--- a/igseq/record.py
+++ b/igseq/record.py
@@ -2,6 +2,7 @@
 Helper classes for records stored in FASTA/FASTQ/CSV/TSV with/without gzip.
 """
 
+import re
 import sys
 import csv
 import gzip
@@ -9,13 +10,13 @@ import logging
 from pathlib import Path
 from Bio import SeqIO
 from Bio.SeqRecord import SeqRecord
-from Bio.Seq import Seq
 from igseq import util
 
 LOGGER = logging.getLogger(__name__)
 
 DEFAULT_DUMMY_QUAL = "I"
-DEFAULT_COLUMNS = {k: k for k in ["sequence_id", "sequence", "sequence_quality", "sequence_description"]}
+DEFAULT_COLUMNS = {
+    k: k for k in ["sequence_id", "sequence", "sequence_quality", "sequence_description"]}
 
 # Mapping from file extensions to file format names used here
 FMT_EXT_MAP = {
@@ -31,7 +32,7 @@ FMT_EXT_MAP = {
 # Mapping from file format names to functions that take file handles and give
 # format-specific record iterators.
 READERS = {
-    "csv": lambda hndl: csv.DictReader(hndl),
+    "csv": csv.DictReader,
     "tsv": lambda hndl: csv.DictReader(hndl, delimiter="\t"),
     "fa": lambda hndl: SeqIO.parse(hndl, "fasta"),
     "fq": lambda hndl: SeqIO.parse(hndl, "fastq")}
@@ -110,33 +111,37 @@ class RecordHandler:
         fmt2 = FMT_EXT_MAP.get(ext2)
         if ext == ".gz" and fmt2:
             return fmt2 + "gz"
-        else:
-            return FMT_EXT_MAP.get(ext)
-
-    def encode_record(self, record):
-        """Convert record dictionary into a SeqRecord object."""
-        seq = record[self.colmap["sequence"]]
-        seqid = record[self.colmap["sequence_id"]]
-        desc = record.get(self.colmap["sequence_description"], "")
-        seqrecord = SeqRecord(Seq(seq), id=seqid, description=desc)
-        quals = record.get(self.colmap["sequence_quality"])
-        if quals:
-            nums = self.decode_phred(quals)
-            seqrecord.letter_annotations["phred_quality"] = nums
-        elif self.dummyqual:
-            nums = self.decode_phred(self.dummyqual * len(seqrecord))
-            seqrecord.letter_annotations["phred_quality"] = nums
-        return seqrecord
+        return FMT_EXT_MAP.get(ext)
 
     def decode_record(self, obj):
         """Convert object (SeqRecord or dictionary) to dictionary."""
         if isinstance(obj, SeqRecord):
+            # (Biopython has some weirdly asymmetric behavior with sequence IDs
+            # and descriptions, so I'm trying to handle that part myself.)
+            if obj.description != "<unknown description>":
+                if obj.description.startswith(obj.id):
+                    # If there's a space, use that as a separator and record
+                    # the description after that space.  If not, just ID.
+                    match = re.match("([^ ]+)( ?)(.*)", obj.description)
+                    seq_id, spacer, seq_desc = match.groups()
+                    if not spacer:
+                        seq_desc = None
+                else:
+                    # If the description *doesn't* have the ID at the start,
+                    # just take both as-is.
+                    seq_id = obj.id
+                    seq_desc = obj.description
+            else:
+                seq_id = obj.id
+                seq_desc = None
             record = {
-                self.colmap["sequence_id"]: obj.id,
+                self.colmap["sequence_id"]: seq_id,
                 self.colmap["sequence"]: str(obj.seq)}
             quals = obj.letter_annotations.get("phred_quality")
             if quals:
                 record[self.colmap["sequence_quality"]] = self.encode_phred(quals)
+            if seq_desc is not None:
+                record["sequence_description"] = seq_desc
         else:
             record = obj
         return record
@@ -232,30 +237,53 @@ class RecordWriter(RecordHandler):
             quals = self.dummyqual * len(record[self.colmap["sequence"]])
             record[self.colmap["sequence_quality"]] = quals
         if not self.dry_run and not self.writer:
+            # order columns like in DEFAULT_COLUMNS with any custom ones on the
+            # end
+            def colsort(val):
+                for idx, key in enumerate(self.colmap):
+                    if self.colmap[key] == val:
+                        return idx
+                return len(DEFAULT_COLUMNS)
+            fieldnames = sorted(record.keys(), key=colsort)
             if self.fmt in ["csv", "csvgz"]:
                 self.writer = csv.DictWriter(
-                    self.handle, fieldnames=record.keys(), lineterminator="\n")
+                    self.handle, fieldnames=fieldnames, lineterminator="\n")
                 self.writer.writeheader()
             elif self.fmt in ["tsv", "tsvgz"]:
                 self.writer = csv.DictWriter(
-                    self.handle, fieldnames=record.keys(), lineterminator="\n", delimiter="\t")
+                    self.handle, fieldnames=fieldnames, lineterminator="\n", delimiter="\t")
                 self.writer.writeheader()
         if self.fmt in ["csv", "tsv", "csvgz", "tsvgz"]:
             if not self.dry_run:
                 self.writer.writerow(record)
         elif self.fmt in ["fa", "fagz"]:
-            seqrecord = self.encode_record(record)
-            if not self.dry_run:
-                SeqIO.write(seqrecord, self.handle, "fasta-2line")
+            self._write_fa(record)
         elif self.fmt in ["fq", "fqgz"]:
-            seqrecord = self.encode_record(record)
-            if not "phred_quality" in seqrecord.letter_annotations:
-                LOGGER.warning(
-                    "No quality scores available, using default dummy value: %s",
-                    DEFAULT_DUMMY_QUAL)
-                self.dummyqual = DEFAULT_DUMMY_QUAL
-            seqrecord = self.encode_record(record)
-            if not self.dry_run:
-                SeqIO.write(seqrecord, self.handle, "fastq")
+            self._write_fq(record)
         else:
             raise ValueError(f"Unknown format {self.fmt}")
+
+    def _write_fa(self, record):
+        seq = record[self.colmap["sequence"]]
+        defline = record[self.colmap["sequence_id"]]
+        desc = record.get(self.colmap["sequence_description"])
+        if desc is not None:
+            defline += f" {desc}"
+        if not self.dry_run:
+            self.handle.write(f">{defline}\n{seq}\n")
+
+    def _write_fq(self, record):
+        seq = record[self.colmap["sequence"]]
+        defline = record[self.colmap["sequence_id"]]
+        desc = record.get(self.colmap["sequence_description"])
+        if self.colmap["sequence_quality"] in record:
+            quals = record[self.colmap["sequence_quality"]]
+        else:
+            LOGGER.warning(
+                "No quality scores available, using default dummy value: %s",
+                DEFAULT_DUMMY_QUAL)
+            quals = "".join(DEFAULT_DUMMY_QUAL * len(seq))
+        if desc is not None:
+            defline += f" {desc}"
+        if not self.dry_run:
+            self.handle.write(f"@{defline}\n{seq}\n+\n{quals}\n")

--- a/test_igseq/data/test_convert/TestConvertDesc/unwrapped.csv
+++ b/test_igseq/data/test_convert/TestConvertDesc/unwrapped.csv
@@ -1,0 +1,2 @@
+sequence_id,sequence,sequence_description
+seqid,ACTGACTGACTGACTG,other stuff

--- a/test_igseq/data/test_convert/TestConvertDesc/unwrapped.fasta
+++ b/test_igseq/data/test_convert/TestConvertDesc/unwrapped.fasta
@@ -1,0 +1,2 @@
+>seqid other stuff
+ACTGACTGACTGACTG

--- a/test_igseq/data/test_convert/TestConvertDesc/unwrapped.fastq
+++ b/test_igseq/data/test_convert/TestConvertDesc/unwrapped.fastq
@@ -1,0 +1,4 @@
+@seqid other stuff
+ACTGACTGACTGACTG
++
+IIIIIIIIIIIIIIII

--- a/test_igseq/data/test_convert/TestConvertDesc/unwrapped.tsv
+++ b/test_igseq/data/test_convert/TestConvertDesc/unwrapped.tsv
@@ -1,0 +1,2 @@
+sequence_id	sequence	sequence_description
+seqid	ACTGACTGACTGACTG	other stuff

--- a/test_igseq/data/test_convert/TestConvertDesc/unwrapped_quals.csv
+++ b/test_igseq/data/test_convert/TestConvertDesc/unwrapped_quals.csv
@@ -1,0 +1,2 @@
+sequence_id,sequence,sequence_quality,sequence_description
+seqid,ACTGACTGACTGACTG,IIIIIIIIIIIIIIII,other stuff

--- a/test_igseq/data/test_convert/TestConvertDesc/unwrapped_quals.tsv
+++ b/test_igseq/data/test_convert/TestConvertDesc/unwrapped_quals.tsv
@@ -1,0 +1,2 @@
+sequence_id	sequence	sequence_quality	sequence_description
+seqid	ACTGACTGACTGACTG	IIIIIIIIIIIIIIII	other stuff

--- a/test_igseq/data/test_convert/TestConvertDesc/wrapped.fasta
+++ b/test_igseq/data/test_convert/TestConvertDesc/wrapped.fasta
@@ -1,0 +1,3 @@
+>seqid other stuff
+ACTGACTG
+ACTGACTG

--- a/test_igseq/data/test_convert/TestConvertPathological/seqs.fa
+++ b/test_igseq/data/test_convert/TestConvertPathological/seqs.fa
@@ -1,0 +1,10 @@
+>name
+ACTG
+>name name
+ACTG
+>name desc
+ACTG
+>namewithspace 
+ACTG
+>namewithtwospaces  
+ACTG

--- a/test_igseq/test_convert.py
+++ b/test_igseq/test_convert.py
@@ -1,4 +1,5 @@
 import subprocess
+from unittest import expectedFailure
 from gzip import open as gzopen
 from io import BytesIO
 from pathlib import Path
@@ -284,6 +285,27 @@ class TestConvert(TestBase):
             self.assertTxtsMatch(
                 self.path/"unwrapped_quals.tsv",
                 Path(tmpdir)/"unwrapped_quals.tsv")
+
+
+class TestConvertDesc(TestConvert):
+    """Test with sequence descriptions (not just ID)"""
+
+
+class TestConvertPathological(TestBase):
+    """Test with strange sequence description lines"""
+
+    @expectedFailure
+    def test_convert_fa_fa(self):
+        """Test converting fasta to fasta.
+
+        These *should* make output identical to the input, but Biopython subtly
+        munges certain strings when it parsed out seq ID vs description.
+        """
+        with TemporaryDirectory() as tmpdir:
+            convert(self.path/"seqs.fasta", Path(tmpdir)/"seqs.fasta")
+            self.assertTxtsMatch(
+                self.path/"seqs.fasta",
+                Path(tmpdir)/"seqs.fasta")
 
 
 class TestConvertDryRun(TestBase):

--- a/test_igseq/test_record.py
+++ b/test_igseq/test_record.py
@@ -31,18 +31,28 @@ class TestRecordHandler(TestBase):
         handler = record.RecordHandler(self.path/"example.xyz", "fa")
         self.assertEqual(handler.fmt, "fa")
 
-    def test_encode_record(self):
-        obj = self.handler.encode_record({"sequence_id": "id", "sequence": "ACTG"})
-        self.assertEqual(obj.id, "id")
-        self.assertEqual(str(obj.seq), "ACTG")
-
     def test_decode_record(self):
-        rec = self.handler.decode_record({"sequence_id": "id", "sequence": "ACTG"})
-        self.assertEqual(rec["sequence_id"], "id")
-        self.assertEqual(rec["sequence"], "ACTG")
-        rec = self.handler.decode_record(SeqRecord(Seq("ACTG"), id="id"))
-        self.assertEqual(rec["sequence_id"], "id")
-        self.assertEqual(rec["sequence"], "ACTG")
+        cases = [
+            (
+                {"sequence_id": "id", "sequence": "ACTG"},
+                {"sequence_id": "id", "sequence": "ACTG"}),
+            (
+                SeqRecord(Seq("ACTG"), id="id"),
+                {"sequence_id": "id", "sequence": "ACTG"}),
+            (
+                {"sequence_id": "id", "sequence": "ACTG", "sequence_description": "desc"},
+                {"sequence_id": "id", "sequence": "ACTG", "sequence_description": "desc"}),
+            (
+                SeqRecord(Seq("ACTG"), id="id"),
+                {"sequence_id": "id", "sequence": "ACTG"}),
+            (
+                SeqRecord(Seq("ACTG"), id="id", description="desc"),
+                {"sequence_id": "id", "sequence": "ACTG", "sequence_description": "desc"}),
+            ]
+        for case in cases:
+            with self.subTest(record=case[0], expected=case[1]):
+                out = self.handler.decode_record(case[0])
+                self.assertEqual(out, case[1])
 
     def test_encode_phred(self):
         txt = self.handler.encode_phred([33, 33, 33])


### PR DESCRIPTION
The existing code was largely ignoring sequence descriptions (the content in the sequence definition line beyond the first space).  This supports tracking that text with a `sequence_description` key (and reading/writing a corresponding column for tabular input/output).  Fixes #45.