### PR TITLE
Fix tree color-code generation when only one set is defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## dev
+
+### Fixed
+
+ * `tree` command can now handle assigning a color code when exactly one
+   sequence set is defined ([#57])
+
+[#57]: https://github.com/ShawHahnLab/igseq/pull/57
+
 ## 0.5.0 - 2023-01-04
 
 ### Added

--- a/igseq/tree.py
+++ b/igseq/tree.py
@@ -314,7 +314,7 @@ def make_seq_set_colors(seq_sets):
         # adapted from SONAR
         # this stretches across COLORS in even increments for as many as we need here
         num = len(colors.COLORS)
-        subset = [int( a * (num-1) / (len(seq_sets)-1) ) for a in range(num)]
+        subset = [int( a * (num-1) / max(1, (len(seq_sets)-1)) ) for a in range(num)]
         try:
             seq_set_colors[set_name] = colors.color_str_to_trio(colors.COLORS[subset[idx]])
         except IndexError:

--- a/test_igseq/test_tree.py
+++ b/test_igseq/test_tree.py
@@ -193,7 +193,7 @@ class TestParseLists(TestBase):
         self.assertEqual(tree.parse_lists(None), {})
 
 
-class TestParseColors(TestBase):
+class TestColors(TestBase):
 
     def test_parse_colors(self):
         # implicit naming
@@ -213,6 +213,19 @@ class TestParseColors(TestBase):
         self.assertEqual(colors, colors_exp)
         # None should be equivalent to no colors given
         self.assertEqual(tree.parse_colors(None), {})
+
+    def test_make_seq_sets_colors(self):
+        # a basic scenario
+        self.assertEqual(
+            tree.make_seq_set_colors({"A": {"seq1", "seq2"}, "B": {"seq3", "seq4"}}),
+            {"A": [190, 66, 41], "B": [209, 134, 215]})
+        # just one set
+        self.assertEqual(
+            tree.make_seq_set_colors({"A": {"A"}}),
+            {"A": [190, 66, 41]})
+        # how about *no* sets?
+        self.assertEqual(tree.make_seq_set_colors({}), {})
+
 
 
 class TestLooksAligned(TestBase):


### PR DESCRIPTION
This handles the special case of just one sequence set being given to the color-code-creating function, where previously it would run into 0/0 and crash.  Now it correctly evaluates to 0 (the index of first color in the canned list).  Fixes #54.