### PR TITLE
Support custom sequence description columns

### DIFF
--- a/igseq/record.py
+++ b/igseq/record.py
@@ -141,7 +141,7 @@ class RecordHandler:
             if quals:
                 record[self.colmap["sequence_quality"]] = self.encode_phred(quals)
             if seq_desc is not None:
-                record["sequence_description"] = seq_desc
+                record[self.colmap["sequence_description"]] = seq_desc
         else:
             record = obj
         return record

--- a/test_igseq/data/test_convert/TestConvertCustomCols/unwrapped_desc.csv
+++ b/test_igseq/data/test_convert/TestConvertCustomCols/unwrapped_desc.csv
@@ -1,0 +1,2 @@
+SeqID,Seq,SeqDesc
+seqid,ACTGACTGACTGACTG,desc

--- a/test_igseq/data/test_convert/TestConvertCustomCols/unwrapped_desc_alt.csv
+++ b/test_igseq/data/test_convert/TestConvertCustomCols/unwrapped_desc_alt.csv
@@ -1,0 +1,3 @@
+SeqID,Seq,SeqDesc
+seqid,ACTGACTGACTGACTG,
+seqid2,TCTGACTCACTGAGTA,desc

--- a/test_igseq/data/test_convert/TestConvertCustomCols/wrapped_desc.fasta
+++ b/test_igseq/data/test_convert/TestConvertCustomCols/wrapped_desc.fasta
@@ -1,0 +1,3 @@
+>seqid desc
+ACTGACTG
+ACTGACTG

--- a/test_igseq/data/test_convert/TestConvertCustomCols/wrapped_desc_alt.fasta
+++ b/test_igseq/data/test_convert/TestConvertCustomCols/wrapped_desc_alt.fasta
@@ -1,0 +1,6 @@
+>seqid
+ACTGACTG
+ACTGACTG
+>seqid2 desc
+TCTGACTC
+ACTGAGTA

--- a/test_igseq/test_convert.py
+++ b/test_igseq/test_convert.py
@@ -352,6 +352,28 @@ class TestConvertCustomCols(TestBase):
                 self.path/"unwrapped.alt2.csv",
                 Path(tmpdir)/"unwrapped.csv")
 
+    @expectedFailure
+    def test_convert_fa_csv_desc(self):
+        """Test converting fasta to csv, with descriptions."""
+        colmap = {"sequence_id": "SeqID", "sequence": "Seq", "sequence_description": "SeqDesc"}
+        # See #59
+        with self.subTest("all descs"), TemporaryDirectory() as tmpdir:
+            convert(
+                self.path/"wrapped_desc.fasta", Path(tmpdir)/"unwrapped_desc.csv",
+                colmap=colmap)
+            self.assertTxtsMatch(
+                self.path/"unwrapped_desc.csv",
+                Path(tmpdir)/"unwrapped_desc.csv")
+        # just to double-check the edge case of seq in, tabular out, and no
+        # desc on first record, since that's given me trouble (see #53)
+        with self.subTest("later desc"), TemporaryDirectory() as tmpdir:
+            convert(
+                self.path/"wrapped_desc_alt.fasta", Path(tmpdir)/"unwrapped_desc_alt.csv",
+                colmap=colmap)
+            self.assertTxtsMatch(
+                self.path/"unwrapped_desc_alt.csv",
+                Path(tmpdir)/"unwrapped_desc_alt.csv")
+
     def test_convert_fq_csv(self):
         """Test converting fastq to csv.
 

--- a/test_igseq/test_convert.py
+++ b/test_igseq/test_convert.py
@@ -352,6 +352,8 @@ class TestConvertCustomCols(TestBase):
                 self.path/"unwrapped.alt2.csv",
                 Path(tmpdir)/"unwrapped.csv")
 
+    # until #53 is fixed
+    @expectedFailure
     def test_convert_fa_csv_desc(self):
         """Test converting fasta to csv, with descriptions."""
         colmap = {"sequence_id": "SeqID", "sequence": "Seq", "sequence_description": "SeqDesc"}

--- a/test_igseq/test_convert.py
+++ b/test_igseq/test_convert.py
@@ -352,7 +352,6 @@ class TestConvertCustomCols(TestBase):
                 self.path/"unwrapped.alt2.csv",
                 Path(tmpdir)/"unwrapped.csv")
 
-    @expectedFailure
     def test_convert_fa_csv_desc(self):
         """Test converting fasta to csv, with descriptions."""
         colmap = {"sequence_id": "SeqID", "sequence": "Seq", "sequence_description": "SeqDesc"}


### PR DESCRIPTION
Implements support for custom sequence description columns in the record-handling that should have been there from the start.  Fixes #59.  The new tests won't fully pass until #53 is also fixed though.