### PR TITLE
Write taxset lines to NEXUS files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## dev
+
+### Added
+
+ * `tree` now writes seq set groupings in NEXUS output files ([#67])
+
+[#67]: https://github.com/ShawHahnLab/igseq/pull/67
+
 ## 0.5.1 - 2023-03-31
 
 ### Changed

--- a/igseq/data/examples/outputs/tree/example_colors.nex
+++ b/igseq/data/examples/outputs/tree/example_colors.nex
@@ -1,4 +1,8 @@
 #NEXUS
+begin sets;
+taxset wk16 = wk16-001 wk16-002 wk16-003
+taxset wk20 = wk20-001 wk20-002 wk20-003
+end;
 begin taxa;
 dimensions ntax=7;
 taxlabels

--- a/igseq/data/examples/outputs/tree/example_lists.nex
+++ b/igseq/data/examples/outputs/tree/example_lists.nex
@@ -1,4 +1,8 @@
 #NEXUS
+begin sets;
+taxset set1 = wk16-001 wk16-002 wk16-003
+taxset set2 = wk20-001 wk20-002 wk20-003
+end;
 begin taxa;
 dimensions ntax=7;
 taxlabels

--- a/igseq/data/examples/outputs/tree/example_multi.nex
+++ b/igseq/data/examples/outputs/tree/example_multi.nex
@@ -1,4 +1,8 @@
 #NEXUS
+begin sets;
+taxset set1 = somethingelse wk16-001 wk16-002 wk16-003 wk20-001 wk20-002 wk20-003
+taxset set2 = wk24-001 wk24-002 wk24-003 wk24-004
+end;
 begin taxa;
 dimensions ntax=11;
 taxlabels

--- a/igseq/data/examples/outputs/tree/example_pattern.nex
+++ b/igseq/data/examples/outputs/tree/example_pattern.nex
@@ -1,4 +1,8 @@
 #NEXUS
+begin sets;
+taxset wk16 = wk16-001 wk16-002 wk16-003
+taxset wk20 = wk20-001 wk20-002 wk20-003
+end;
 begin taxa;
 dimensions ntax=7;
 taxlabels

--- a/igseq/data/examples/outputs/tree/example_pattern_from_newick.nex
+++ b/igseq/data/examples/outputs/tree/example_pattern_from_newick.nex
@@ -1,4 +1,8 @@
 #NEXUS
+begin sets;
+taxset wk16 = wk16-001 wk16-002 wk16-003
+taxset wk20 = wk20-001 wk20-002 wk20-003
+end;
 begin taxa;
 dimensions ntax=7;
 taxlabels

--- a/igseq/tree.py
+++ b/igseq/tree.py
@@ -135,7 +135,7 @@ def tree(paths_in, path_out, fmt_in=None, fmt_out=None, aligned=None, pattern=No
         seq_ids = all_leaf_ids(newick_obj)
         seq_sets_combo = build_seq_sets(seq_ids, pattern, seq_sets)
         seq_colors = color_seqs(seq_ids, seq_sets_combo, colors)
-        save_nexus(seq_colors, newick_obj, path_out)
+        save_nexus(newick_obj, path_out, seq_colors, seq_sets_combo)
     else:
         raise NotImplementedError("image output not yet implemented")
 
@@ -321,10 +321,17 @@ def make_seq_set_colors(seq_sets):
             seq_set_colors[set_name] = [random.randint(0, 255) for _ in range(3)]
     return seq_set_colors
 
-def save_nexus(seq_colors, newick_obj, path):
+def save_nexus(newick_obj, path, seq_colors, seq_sets=None):
     newick_text = newick.dumps(newick_obj)
     with open(path, "wt") as f_out:
         f_out.write("#NEXUS\n")
+        if seq_sets:
+            # https://plewis.github.io/nexus/#sets-block
+            f_out.write("begin sets;\n")
+            for set_key, set_seqids in seq_sets.items():
+                set_seqids_txt = " ".join(sorted(set_seqids))
+                f_out.write(f"taxset {set_key} = {set_seqids_txt}\n")
+            f_out.write("end;\n")
         f_out.write("begin taxa;\n")
         f_out.write(f"dimensions ntax={len(seq_colors)};\n")
         f_out.write("taxlabels\n")

--- a/test_igseq/data/test_tree/TestTreeMulti/tree.nex
+++ b/test_igseq/data/test_tree/TestTreeMulti/tree.nex
@@ -1,4 +1,8 @@
 #NEXUS
+begin sets;
+taxset set1 = seq1 seq2 seq3
+taxset set2 = seq1 seq4
+end;
 begin taxa;
 dimensions ntax=4;
 taxlabels

--- a/test_igseq/data/test_tree/TestTreeMultiGaps/tree.nex
+++ b/test_igseq/data/test_tree/TestTreeMultiGaps/tree.nex
@@ -1,4 +1,8 @@
 #NEXUS
+begin sets;
+taxset set1 = seq1 seq2 seq3
+taxset set2 = seq1 seq4
+end;
 begin taxa;
 dimensions ntax=4;
 taxlabels


### PR DESCRIPTION
Updates `igseq tree` to add "taxset" lines detailing seq set groupings when writing NEXUS files.  Fixes #56.