### PR TITLE
Fix PhiX counts path handling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build:
     machine:
-      image: ubuntu-2004:202201-02
+      image: default
     steps:
       - checkout:
           path: igseq

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@
 
  * `tree` now writes seq set groupings in NEXUS output files ([#67])
 
+### Changed
+
+ * `igblast` has its version pinned at 1.21.0 rather than left unspecified
+   ([#70])
+
+### Fixed
+
+ * `phix` can accept a custom path for the read counts CSV file ([#74])
+
+[#74]: https://github.com/ShawHahnLab/igseq/pull/74
+[#70]: https://github.com/ShawHahnLab/igseq/pull/70
 [#67]: https://github.com/ShawHahnLab/igseq/pull/67
 
 ## 0.5.1 - 2023-03-31

--- a/igseq/phix.py
+++ b/igseq/phix.py
@@ -39,6 +39,8 @@ def phix(paths_input, bam_out="", counts_out="", dry_run=False, threads=1):
         bam_out = Path(bam_out)
     if counts_out == "":
         counts_out = bam_out.with_suffix(".counts.csv")
+    else:
+        counts_out = Path(counts_out)
     LOGGER.info("input R1: %s", paths_input["R1"])
     LOGGER.info("input R2: %s", paths_input["R2"])
     LOGGER.info("output bam: %s", bam_out)

--- a/test_igseq/test_phix.py
+++ b/test_igseq/test_phix.py
@@ -25,3 +25,17 @@ class TestPhixLive(TestBase, TestLive):
             # does too.
             with open(path/"phix/run/phix.counts.csv", encoding="ASCII") as f_in:
                 self.assertEqual(f_in.read(), "Category,Sample,Item,NumSeqs\nphix,,mapped,1\n")
+
+    def test_phix_custom_counts(self):
+        with TemporaryDirectory() as temp:
+            path = Path(temp)
+            copytree(self.path/"input", path/"input")
+            phix([path/"input/run"], counts_out=str(path/"phix/run/custom_counts_path.csv"))
+            # Check that the output filenames all match up
+            files = sorted([p.name for p in (path/"phix/run").glob("*")])
+            files_expected = sorted(["phix.bam", "custom_counts_path.csv"])
+            self.assertEqual(files_expected, files)
+            # Check the read counts.  If this looks right we'll assume the bam
+            # does too.
+            with open(path/"phix/run/custom_counts_path.csv", encoding="ASCII") as f_in:
+                self.assertEqual(f_in.read(), "Category,Sample,Item,NumSeqs\nphix,,mapped,1\n")


### PR DESCRIPTION
If an optional custom path is given for the counts CSV for phix, it will be properly cast as a Path object. Fixes #68.  This also switches from the [deprecated](https://discuss.circleci.com/t/linux-image-deprecations-and-eol-for-2024/50177) CircleCI image `ubuntu-2004:202201-02` to just using `default`.