### PR TITLE
Handle exceptions in igblast stdin thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,10 @@
 
 ### Fixed
 
+ * `igblast` now handles crashes during file input more clearly ([#75])
  * `phix` can accept a custom path for the read counts CSV file ([#74])
 
+[#75]: https://github.com/ShawHahnLab/igseq/pull/75
 [#74]: https://github.com/ShawHahnLab/igseq/pull/74
 [#70]: https://github.com/ShawHahnLab/igseq/pull/70
 [#67]: https://github.com/ShawHahnLab/igseq/pull/67

--- a/test_igseq/test_igblast.py
+++ b/test_igseq/test_igblast.py
@@ -98,3 +98,14 @@ class TestIgblastLiveCrash(TestBase, TestLive):
         stdout, stderr = self.redirect_streams(catch_expected_error)
         self.assertEqual(stdout, "")
         self.assertIn('Error: Unknown argument: "bad-arg"', stderr)
+
+    def test_igblast_thread_crash(self):
+        """Test that crashes within the input thread are handled properly."""
+        # Using a file name that doesn't exist
+        def catch_expected_error():
+            with self.assertRaises(IgSeqError):
+                igblast.igblast(
+                    ["rhesus/imgt"], self.path/"input/query2.fasta")
+        stdout, stderr = self.redirect_streams(catch_expected_error)
+        self.assertEqual(stdout, "")
+        self.assertIn("No such file or directory", stderr)


### PR DESCRIPTION
If an exception occurs in the thread that reads input and passes it to an igblast process, the crash is handled more clearly, and an `IgSeqError` is raised in the main thread.  Fixes #73.