### PR TITLE
Default to simpler set-based color-coding in tree output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Changed
 
+ * `tree` defaults to simpler color-coding logic for sets of sequences (for
+   sequences in multiple sets, by default the last set's color is used) ([#77])
  * `igblast` has its version pinned at 1.21.0 rather than left unspecified
    ([#70])
 
@@ -16,6 +18,7 @@
  * `igblast` now handles crashes during file input more clearly ([#75])
  * `phix` can accept a custom path for the read counts CSV file ([#74])
 
+[#77]: https://github.com/ShawHahnLab/igseq/pull/77
 [#75]: https://github.com/ShawHahnLab/igseq/pull/75
 [#74]: https://github.com/ShawHahnLab/igseq/pull/74
 [#70]: https://github.com/ShawHahnLab/igseq/pull/70

--- a/igseq/__main__.py
+++ b/igseq/__main__.py
@@ -263,6 +263,7 @@ def _main_tree(args):
         pattern=args.set_pattern,
         lists=args.set_list,
         colors=args.set_color,
+        merge_colors=args.merge_colors,
         colmap=colmap,
         dry_run=args.dry_run)
 
@@ -599,6 +600,9 @@ def __setup_arg_parser():
     p_tree.add_argument("--set-color", "-C", action="append",
         help="setname=colorcode, like set1=#ff0000, to override automatic set colors. "
         "This can be given multiple times for multiple set/color pairs.")
+    p_tree.add_argument("--merge-colors", "-M", action="store_true",
+        help="merge the set colors applying to each sequence?  Otherwise (the default) apply "
+        "colors set-by-set with the last set taking precedence")
     p_tree.set_defaults(func=_main_tree)
 
     return parser

--- a/igseq/data/examples/tree.sh
+++ b/igseq/data/examples/tree.sh
@@ -25,8 +25,7 @@ igseq tree $FASTA -P '^wk[0-9]+' example_pattern.nex
 # color-coded NEXUS file from that.
 igseq tree example.tree -P '^wk[0-9]+' example_pattern_from_newick.nex
 
-# Or, define sets by lists of sequence IDs.  (Here these are "set1" and
-# "set2"; they could also be named like "-L wk16=wk16.txt -L wk20=wk20.txt".)
+# Or, define sets by lists of sequence IDs.
 igseq tree $FASTA -L $WK16 -L $WK20 example_lists.nex
 
 # We can override colors using the set names found in the IDs based on that

--- a/test_igseq/data/test_tree/TestTreeMulti/tree_merged.nex
+++ b/test_igseq/data/test_tree/TestTreeMulti/tree_merged.nex
@@ -6,7 +6,7 @@ end;
 begin taxa;
 dimensions ntax=4;
 taxlabels
-'seq1'[&!color=#d186d7]
+'seq1'[&!color=#000000]
 'seq2'[&!color=#be4229]
 'seq3'[&!color=#be4229]
 'seq4'[&!color=#d186d7]

--- a/test_igseq/data/test_tree/TestTreeMultiGaps/tree.nex
+++ b/test_igseq/data/test_tree/TestTreeMultiGaps/tree.nex
@@ -6,7 +6,7 @@ end;
 begin taxa;
 dimensions ntax=4;
 taxlabels
-'seq1'[&!color=#000000]
+'seq1'[&!color=#d186d7]
 'seq2'[&!color=#be4229]
 'seq3'[&!color=#be4229]
 'seq4'[&!color=#d186d7]

--- a/test_igseq/data/test_tree/TestTreeMultiGaps/tree_merged.nex
+++ b/test_igseq/data/test_tree/TestTreeMultiGaps/tree_merged.nex
@@ -6,7 +6,7 @@ end;
 begin taxa;
 dimensions ntax=4;
 taxlabels
-'seq1'[&!color=#d186d7]
+'seq1'[&!color=#000000]
 'seq2'[&!color=#be4229]
 'seq3'[&!color=#be4229]
 'seq4'[&!color=#d186d7]

--- a/test_igseq/test_tree.py
+++ b/test_igseq/test_tree.py
@@ -133,17 +133,28 @@ class TestTreeMulti(TestBase):
         # a special case: multiple FASTA inputs will allow implicit set
         # membership based on which files have which sequences
         with TemporaryDirectory() as tmpdir:
-            stdout, stderr = self.redirect_streams(lambda:
+            self.redirect_streams(lambda:
                 tree.tree(
                     [self.path/"seqs.fasta", self.path/"seqs2.fasta"],
                     Path(tmpdir)/"tree.tree"))
             self.assertTxtsMatch(self.path/"tree.tree", Path(tmpdir)/"tree.tree")
+        # default behavior: for overlapping set membership for any given
+        # sequence, the color from the last set is applied
         with TemporaryDirectory() as tmpdir:
-            stdout, stderr = self.redirect_streams(lambda:
+            self.redirect_streams(lambda:
                 tree.tree(
                     [self.path/"seqs.fasta", self.path/"seqs2.fasta"],
                     Path(tmpdir)/"tree.nex"))
             self.assertTxtsMatch(self.path/"tree.nex", Path(tmpdir)/"tree.nex")
+        # merge behavior: for overlapping set membership for any given
+        # sequence, the colors from all sets containing that sequence are
+        # merged
+        with TemporaryDirectory() as tmpdir:
+            self.redirect_streams(lambda:
+                tree.tree(
+                    [self.path/"seqs.fasta", self.path/"seqs2.fasta"],
+                    Path(tmpdir)/"tree_merged.nex", merge_colors=True))
+            self.assertTxtsMatch(self.path/"tree_merged.nex", Path(tmpdir)/"tree_merged.nex")
 
 
 class TestTreeMultiGaps(TestTreeMulti):
@@ -225,7 +236,6 @@ class TestColors(TestBase):
             {"A": [190, 66, 41]})
         # how about *no* sets?
         self.assertEqual(tree.make_seq_set_colors({}), {})
-
 
 
 class TestLooksAligned(TestBase):


### PR DESCRIPTION
For `igseq tree` NEXUS output, this switches to a simpler last-set-takes-precedence default approach when selecting colors for sequences present in multiple sets. Fixes #76.