### PR TITLE
Support custom adapters for trim command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+ * `trim` now supports custom forward and/or reverse adapter sequences ([#88])
  * `trim` now supports passing additional command-line arguments through to
    cutadapt ([#87])
 
@@ -13,6 +14,7 @@
    in the samples CSV to be missing or blank, in which case any applicable
    adapter sequences will be used in the cutadapt commands ([#85])
 
+[#88]: https://github.com/ShawHahnLab/igseq/pull/88
 [#87]: https://github.com/ShawHahnLab/igseq/pull/87
 [#85]: https://github.com/ShawHahnLab/igseq/pull/85
 


### PR DESCRIPTION
Adds support for custom forward and/or reverse adapter sequences in the trim command.  The default behavior of requiring the (linked and anchored) forward adapter is disabled for a custom forward adapter, unless it also starts with the `^` character that cutadapt uses to signify an anchored sequence.  Fixes #66.