### PR TITLE
Add explain command to give background context on concepts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+ * `explain` command to show help text for common concepts (starting with the
+   sample metadata CSV used by `demux` and `trim`) ([#89])
  * `trim` now supports custom forward and/or reverse adapter sequences ([#88])
  * `trim` now supports passing additional command-line arguments through to
    cutadapt ([#87])
@@ -14,6 +16,7 @@
    in the samples CSV to be missing or blank, in which case any applicable
    adapter sequences will be used in the cutadapt commands ([#85])
 
+[#89]: https://github.com/ShawHahnLab/igseq/pull/89
 [#88]: https://github.com/ShawHahnLab/igseq/pull/88
 [#87]: https://github.com/ShawHahnLab/igseq/pull/87
 [#85]: https://github.com/ShawHahnLab/igseq/pull/85

--- a/igseq/__main__.py
+++ b/igseq/__main__.py
@@ -379,7 +379,7 @@ def __setup_arg_parser():
 
     __add_common_args(p_demux)
     p_demux.add_argument("-s", "--samples", required=True,
-        help="CSV of sample attributes")
+        help="CSV of sample attributes (see `igseq explain samples`)")
     p_demux.add_argument("-r", "--run",
         help="Run ID (default: parsed from input paths)")
     p_demux.add_argument("-o", "--outdir", default="",
@@ -409,7 +409,7 @@ def __setup_arg_parser():
 
     __add_common_args(p_trim)
     p_trim.add_argument("-s", "--samples", required=True,
-        help="CSV of sample attributes")
+        help="CSV of sample attributes (see `igseq explain samples`)")
     p_trim.add_argument("-o", "--outdir", default="",
         help="Output directory")
     p_trim.add_argument("-c", "--countsfile", default="",

--- a/igseq/__main__.py
+++ b/igseq/__main__.py
@@ -22,6 +22,7 @@ from . import identity
 from . import msa
 from . import tree
 from . import show
+from . import explain
 from .util import IgSeqError
 from .version import __version__
 
@@ -179,6 +180,9 @@ def _main_show(args):
 
 def _main_list(args):
     show.list_files(text_items=args.text)
+
+def _main_explain(args):
+    explain.explain(keyword=args.keyword)
 
 def _main_igblast(args, extra_igblastn_args=None):
     colmap = args_to_colmap(args)
@@ -355,6 +359,10 @@ def __setup_arg_parser():
         help="list builtin reference data files",
         description=rewrap(show.__doc__),
         formatter_class=argparse.RawDescriptionHelpFormatter)
+    p_explain = subps.add_parser("explain",
+        help="explain concepts used in multiple commands",
+        description=rewrap(explain.__doc__),
+        formatter_class=argparse.RawDescriptionHelpFormatter)
 
     __add_common_args(p_get)
     p_get.add_argument("input", help="one Illumina run directory")
@@ -456,6 +464,11 @@ def __setup_arg_parser():
     __add_common_args(p_list)
     p_list.add_argument("text", nargs="*", help="partial filename to list")
     p_list.set_defaults(func=_main_list)
+
+    __add_common_args(p_explain)
+    p_explain.add_argument("keyword", nargs="?",
+        help="term to show explanation for")
+    p_explain.set_defaults(func=_main_explain)
 
     __add_common_args(p_igblast)
     p_igblast.add_argument("-Q", "--query", required=True,

--- a/igseq/data/explain/samples.txt
+++ b/igseq/data/explain/samples.txt
@@ -1,0 +1,29 @@
+CSV of sample metadata used in demux and trim
+
+The demux and trim commands use a common sample metadata CSV file.
+
+Columns used:
+
+    Sample      Sample name, unique for a given run
+    Run         Sequencing run identifier
+    BarcodeFwd  ID of forward barcode (see igseq show barcodes)
+    BarcodeRev  ID of reverse barcode (ditto)
+    Type        Constant region type (see igseq show primers)
+
+(Any other columns are ignored.) 
+
+The sample names are used during demultiplexing to control file output for
+reads with matching barcodes.  These are filtered to just the matching
+sequencing run according to the Run column (matching what's given on the
+command-line or inferred from input paths) but the sample names must be unique
+for that run.
+
+The barcodes are numbers that correspond to the built-in table of igseq barcode
+sequences.  The barcode sequences are used during demultiplexing, but
+additionally the forward barcode is used during adapter trimming as part of the
+sequence to remove from the end of R2.
+
+Type is used during adapter trimming to include the expected constant region
+sequence past the start of R2 as part of the sequence to trim from the end of
+R1.  If this column is missing or left blank any applicable sequence will be
+trimmed from the 3' end of R1 rather than just one (e.g., "gamma").

--- a/igseq/explain.py
+++ b/igseq/explain.py
@@ -1,0 +1,31 @@
+"""
+Show explanations for concepts used in multiple commands.
+
+The explain command takes a key word (currently just "samples") and shows a
+summary explanation.  Run without arguments to see a list of available entries.
+"""
+
+from .util import DATA, IgSeqError
+from .show import show_text
+
+def __load_explanations(path):
+    paths = sorted((DATA/"explain").glob("*.txt"))
+    paths = {path.stem: path for path in paths}
+    return paths
+
+EXPLANATIONS = __load_explanations(DATA/"explain")
+
+def explain(keyword=None):
+    """Print an explanation for an IgSeq concept to stdout"""
+    if keyword:
+        try:
+            path = EXPLANATIONS[keyword]
+        except KeyError as err:
+            raise IgSeqError(f"key word should be one of {list(EXPLANATIONS.keys())}") from err
+        show_text(path)
+    else:
+        print("Available entries:")
+        for key, path in EXPLANATIONS.items():
+            with open(path, encoding="UTF8") as f_in:
+                preview = next(f_in).rstrip()
+            print(f"    {key}  {preview}")


### PR DESCRIPTION
Adds `explain` to print explanations of concepts that apply for multiple commands (currently just "samples" to explain the samples CSV used by the demux and trim commands).  Fixes #83.