### PR TITLE
Make igblast work with empty input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,11 @@
 
 ### Fixed
 
+ * `igblast` no longer hangs with empty input ([#94])
  * `vdj-gather` can handle multiple input paths with sequences for the same
    segment (for example, IGHV sequences from two germline references) ([#93])
 
+[#94]: https://github.com/ShawHahnLab/igseq/pull/94
 [#93]: https://github.com/ShawHahnLab/igseq/pull/93
 [#89]: https://github.com/ShawHahnLab/igseq/pull/89
 [#88]: https://github.com/ShawHahnLab/igseq/pull/88

--- a/igseq/igblast.py
+++ b/igseq/igblast.py
@@ -192,6 +192,10 @@ def run_igblast(
                         for rec in reader:
                             stdin_started.set()
                             writer.write(rec)
+                        # Calling set() again here so that even if there were
+                        # actually no records in the input at all, we still can
+                        # move forward (see #90)
+                        stdin_started.set()
                 except BrokenPipeError:
                     pass
             except Exception as err:


### PR DESCRIPTION
This fixes the threading logic around calling igblastn so that `igseq igblast` no longer hangs when given empty input. Fixes #90.