### PR TITLE
Fix sequence ID column name handling for identity feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,13 @@
 
 ### Fixed
 
+ * `identity` now handles an optional alternate sequence ID column correctly
+   for the reference input file ([#95])
  * `igblast` no longer hangs with empty input ([#94])
  * `vdj-gather` can handle multiple input paths with sequences for the same
    segment (for example, IGHV sequences from two germline references) ([#93])
 
+[#95]: https://github.com/ShawHahnLab/igseq/pull/95
 [#94]: https://github.com/ShawHahnLab/igseq/pull/94
 [#93]: https://github.com/ShawHahnLab/igseq/pull/93
 [#89]: https://github.com/ShawHahnLab/igseq/pull/89

--- a/igseq/identity.py
+++ b/igseq/identity.py
@@ -59,7 +59,7 @@ def identity(path_in, path_out, path_ref=None, fmt_in=None, fmt_in_ref=None, col
                     ref[reader.colmap["sequence"]])
                 writer.write({
                     "query": record[reader.colmap["sequence_id"]],
-                    "ref": ref["sequence_id"],
+                    "ref": ref[reader.colmap["sequence_id"]],
                     "identity": score})
 
 def score_identity(seq1, seq2):

--- a/test_igseq/data/test_identity/TestIdentityTabular/input_ref.csv
+++ b/test_igseq/data/test_identity/TestIdentityTabular/input_ref.csv
@@ -1,2 +1,2 @@
-sequence_id,sequence,sequence2
-ref,ACTGACTGACTACTGG,CCAGTAGTCAGTCAGT
+sequence_id,sequence_id2,sequence,sequence2
+ref,reference,ACTGACTGACTACTGG,CCAGTAGTCAGTCAGT

--- a/test_igseq/data/test_identity/TestIdentityTabular/input_ref_col3.fa
+++ b/test_igseq/data/test_identity/TestIdentityTabular/input_ref_col3.fa
@@ -1,0 +1,2 @@
+>reference
+ACTGACTGACTACTGG

--- a/test_igseq/data/test_identity/TestIdentityTabular/output_col3.csv
+++ b/test_igseq/data/test_identity/TestIdentityTabular/output_col3.csv
@@ -1,4 +1,4 @@
 query,ref,identity
-seqA,ref,1.0
-seqB,ref,0.8125
-seqC,ref,0.875
+seqA,reference,1.0
+seqB,reference,0.8125
+seqC,reference,0.875

--- a/test_igseq/test_identity.py
+++ b/test_igseq/test_identity.py
@@ -1,6 +1,6 @@
+"""Tests for igseq.identity."""
+
 import unittest
-from tempfile import TemporaryDirectory
-from pathlib import Path
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 from igseq.identity import identity, score_identity
@@ -13,32 +13,33 @@ class TestIdentity(TestBase):
     def test_identity(self):
         """Basic test of identity with FASTA inputs."""
         # Here a FASTA query and FASTA ref can give CSV output
-        with TemporaryDirectory() as tmpdir:
+        identity(
+            self.path/"input_query.fasta",
+            self.tmp/"output.csv",
+            self.path/"input_ref.fasta")
+        self.assertTxtsMatch(self.path/"output.csv", self.tmp/"output.csv")
+
+    def test_identity_colmap(self):
+        """Test identity with FASTA inputs but column names specified."""
+        # should warn if colmap given but not using tabular inputs
+        with self.assertLogs(level="WARNING"):
             identity(
                 self.path/"input_query.fasta",
-                Path(tmpdir)/"output.csv",
-                self.path/"input_ref.fasta")
-            self.assertTxtsMatch(self.path/"output.csv", Path(tmpdir)/"output.csv")
-            # should warn if colmap given but not using tabular inputs
-            with self.assertLogs(level="WARNING"):
-                identity(
-                    self.path/"input_query.fasta",
-                    Path(tmpdir)/"output.csv",
-                    self.path/"input_ref.fasta",
-                    colmap={"sequence": "sequence2"})
-                self.assertTxtsMatch(self.path/"output.csv", Path(tmpdir)/"output.csv")
+                self.tmp/"output.csv",
+                self.path/"input_ref.fasta",
+                colmap={"sequence": "sequence2"})
+            self.assertTxtsMatch(self.path/"output.csv", self.tmp/"output.csv")
 
     def test_identity_aa(self):
         """Test using amino acid sequences."""
-        with TemporaryDirectory() as tmpdir:
-            identity(
-                self.path/"input_query_aa.fasta",
-                Path(tmpdir)/"output_aa.csv",
-                self.path/"input_ref_aa.fasta")
+        identity(
+            self.path/"input_query_aa.fasta",
+            self.tmp/"output_aa.csv",
+            self.path/"input_ref_aa.fasta")
 
     def test_identity_stdout(self):
         """Test writing output to stdout."""
-        with open(self.path/"output.csv") as f_in:
+        with open(self.path/"output.csv", encoding="ASCII") as f_in:
             stdout_expected = f_in.read()
         stdout, stderr = self.redirect_streams(
             lambda: identity(
@@ -50,40 +51,37 @@ class TestIdentity(TestBase):
 
     def test_identity_dryrun(self):
         """Test that dry run won't write an output file."""
-        with TemporaryDirectory() as tmpdir:
-            identity(
-                self.path/"input_query.fasta",
-                Path(tmpdir)/"output.csv",
-                self.path/"input_ref.fasta",
-                dry_run=True)
-            self.assertFalse((Path(tmpdir)/"output.scv").exists())
+        identity(
+            self.path/"input_query.fasta",
+            self.tmp/"output.csv",
+            self.path/"input_ref.fasta",
+            dry_run=True)
+        self.assertFalse((self.tmp/"output.csv").exists())
 
     def test_identity_single(self):
         """Identity with implicit ref via query."""
         # In this case the first record in the query will be used as the
         # reference.
-        with TemporaryDirectory() as tmpdir:
+        identity(
+            self.path/"input_query.fasta",
+            self.tmp/"output.csv")
+        self.assertTxtsMatch(self.path/"output_single.csv", self.tmp/"output.csv")
+        # should warn if ref format is specified but no ref path given
+        with self.assertLogs(level="WARNING"):
             identity(
                 self.path/"input_query.fasta",
-                Path(tmpdir)/"output.csv")
-            self.assertTxtsMatch(self.path/"output_single.csv", Path(tmpdir)/"output.csv")
-            # should warn if ref format is specified but no ref path given
-            with self.assertLogs(level="WARNING"):
-                identity(
-                    self.path/"input_query.fasta",
-                    Path(tmpdir)/"output.csv",
-                    fmt_in_ref="fa")
-            self.assertTxtsMatch(self.path/"output_single.csv", Path(tmpdir)/"output.csv")
+                self.tmp/"output.csv",
+                fmt_in_ref="fa")
+        self.assertTxtsMatch(self.path/"output_single.csv", self.tmp/"output.csv")
 
     def test_identity_csvgz_out(self):
         """Identity with csv.gz output."""
-        with TemporaryDirectory() as tmpdir:
-            identity(
-                self.path/"input_query.fasta",
-                Path(tmpdir)/"output.csv.gz",
-                self.path/"input_ref.fasta")
-            gunzip(Path(tmpdir)/"output.csv.gz")
-            self.assertTxtsMatch(self.path/"output.csv", Path(tmpdir)/"output.csv")
+        identity(
+            self.path/"input_query.fasta",
+            self.tmp/"output.csv.gz",
+            self.path/"input_ref.fasta")
+        gunzip(self.tmp/"output.csv.gz")
+        self.assertTxtsMatch(self.path/"output.csv", self.tmp/"output.csv")
 
 
 class TestIdentityTabular(TestBase):
@@ -94,42 +92,41 @@ class TestIdentityTabular(TestBase):
         # Here a CSV query and CSV ref can give CSV output
         # the defaults are the same as for convert() so sequence_id and
         # sequence columns will be used.
-        with TemporaryDirectory() as tmpdir:
-            identity(
-                self.path/"input_query.csv",
-                Path(tmpdir)/"output.csv",
-                self.path/"input_ref.csv")
-            self.assertTxtsMatch(self.path/"output.csv", Path(tmpdir)/"output.csv")
+        identity(
+            self.path/"input_query.csv",
+            self.tmp/"output.csv",
+            self.path/"input_ref.csv")
+        self.assertTxtsMatch(self.path/"output.csv", self.tmp/"output.csv")
 
-    def test_identity_columns(self):
-        """Test using different columns from input."""
+    def test_identity_columns_seq(self):
+        """Test using different columns from input (seq)."""
         # Here a CSV query and CSV ref can give CSV output.
         # The defaults are the same as for convert() so sequence_id and
         # sequence columns will be used unless overridden.
-        with TemporaryDirectory() as tmpdir:
-            identity(
-                self.path/"input_query.csv",
-                Path(tmpdir)/"output.csv",
-                self.path/"input_ref.csv",
-                colmap={"sequence": "sequence2"})
-            self.assertTxtsMatch(self.path/"output_col2.csv", Path(tmpdir)/"output.csv")
-        with TemporaryDirectory() as tmpdir:
-            identity(
-                self.path/"input_query.csv",
-                Path(tmpdir)/"output.csv",
-                self.path/"input_ref.csv",
-                colmap={"sequence_id": "sequence_id2"})
-            self.assertTxtsMatch(self.path/"output_col3.csv", Path(tmpdir)/"output.csv")
+        identity(
+            self.path/"input_query.csv",
+            self.tmp/"output.csv",
+            self.path/"input_ref.csv",
+            colmap={"sequence": "sequence2"})
+        self.assertTxtsMatch(self.path/"output_col2.csv", self.tmp/"output.csv")
+
+    def test_identity_columns_seqid(self):
+        """Test using different columns from input (seq ID)."""
+        identity(
+            self.path/"input_query.csv",
+            self.tmp/"output.csv",
+            self.path/"input_ref.csv",
+            colmap={"sequence_id": "sequence_id2"})
+        self.assertTxtsMatch(self.path/"output_col3.csv", self.tmp/"output.csv")
 
     def test_identity_single(self):
         """Identity with implicit ref via query."""
         # In this case the first record in the query will be used as the
         # reference.
-        with TemporaryDirectory() as tmpdir:
-            identity(
-                self.path/"input_query.csv",
-                Path(tmpdir)/"output.csv")
-            self.assertTxtsMatch(self.path/"output_single.csv", Path(tmpdir)/"output.csv")
+        identity(
+            self.path/"input_query.csv",
+            self.tmp/"output.csv")
+        self.assertTxtsMatch(self.path/"output_single.csv", self.tmp/"output.csv")
 
 
 class TestScoreIdentity(unittest.TestCase):

--- a/test_igseq/test_identity.py
+++ b/test_igseq/test_identity.py
@@ -27,7 +27,7 @@ class TestIdentity(TestBase):
                 self.path/"input_query.fasta",
                 self.tmp/"output.csv",
                 self.path/"input_ref.fasta",
-                colmap={"sequence": "sequence2"})
+                colmap={"sequence_id": "sequence_id2", "sequence": "sequence2"})
             self.assertTxtsMatch(self.path/"output.csv", self.tmp/"output.csv")
 
     def test_identity_aa(self):
@@ -116,6 +116,15 @@ class TestIdentityTabular(TestBase):
             self.path/"input_query.csv",
             self.tmp/"output.csv",
             self.path/"input_ref.csv",
+            colmap={"sequence_id": "sequence_id2"})
+        self.assertTxtsMatch(self.path/"output_col3.csv", self.tmp/"output.csv")
+
+    def test_identity_columns_seqid_ref_fa(self):
+        """Test using different columns from input (seq ID, and FASTA for ref)."""
+        identity(
+            self.path/"input_query.csv",
+            self.tmp/"output.csv",
+            self.path/"input_ref_col3.fa",
             colmap={"sequence_id": "sequence_id2"})
         self.assertTxtsMatch(self.path/"output_col3.csv", self.tmp/"output.csv")
 


### PR DESCRIPTION
This makes the sequence ID key handling logic consistent in `igseq.identity` when working with either tabular input or FASTA/FASTQ input for the reference file.  Fixes #92.